### PR TITLE
Initialize package structure and configuration

### DIFF
--- a/committee_manager/__init__.py
+++ b/committee_manager/__init__.py
@@ -1,0 +1,19 @@
+"""Top-level package for committee_manager."""
+
+import logging
+
+__author__ = "Example Author"
+__email__ = "author@example.com"
+__version__ = "0.1.0"
+
+logger = logging.getLogger("committee_manager")
+if not logger.handlers:
+    handler = logging.StreamHandler()
+    formatter = logging.Formatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    )
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+
+__all__ = ["logger"]

--- a/committee_manager/cli/__init__.py
+++ b/committee_manager/cli/__init__.py
@@ -1,0 +1,1 @@
+"""Command-line interface for committee_manager."""

--- a/committee_manager/engine/__init__.py
+++ b/committee_manager/engine/__init__.py
@@ -1,0 +1,1 @@
+"""Core engine for committee_manager."""

--- a/committee_manager/models/__init__.py
+++ b/committee_manager/models/__init__.py
@@ -1,0 +1,1 @@
+"""Data models for committee_manager."""

--- a/committee_manager/rules/__init__.py
+++ b/committee_manager/rules/__init__.py
@@ -1,0 +1,1 @@
+"""Business rules for committee_manager."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=67", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "committee_manager"
+version = "0.1.0"
+description = "A package for managing committees."
+readme = "README.md"
+requires-python = ">=3.8"
+license = {text = "MIT"}
+authors = [{name = "Example Author", email = "author@example.com"}]
+dependencies = []


### PR DESCRIPTION
## Summary
- scaffold `committee_manager` package with submodules for models, rules, engine, and CLI
- add basic logger and metadata in package initializer
- add `pyproject.toml` with setuptools-based project configuration

## Testing
- `python -m pytest`
- `python -m compileall -q committee_manager`


------
https://chatgpt.com/codex/tasks/task_e_68bec76a2a8c8322a183fe103b4ab0cd