### PR TITLE
Add person and committee dataclasses

### DIFF
--- a/committee_manager/models/__init__.py
+++ b/committee_manager/models/__init__.py
@@ -1,1 +1,6 @@
 """Data models for committee_manager."""
+
+from .person import Person
+from .committee import Committee
+
+__all__ = ["Person", "Committee"]

--- a/committee_manager/models/committee.py
+++ b/committee_manager/models/committee.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Set
+
+from .person import Person
+
+
+@dataclass
+class Committee:
+    """Represents a committee with membership requirements."""
+
+    name: str
+    min_size: int
+    max_size: int
+    required_competencies: Set[str] = field(default_factory=set)
+    exclusions: Set[Person] = field(default_factory=set)
+    diversity_targets: Dict[str, int] = field(default_factory=dict)
+    members: Set[Person] = field(default_factory=set)
+
+    def __post_init__(self) -> None:
+        if self.min_size < 0 or self.max_size < 0:
+            raise ValueError("Committee sizes must be non-negative")
+        if self.max_size < self.min_size:
+            raise ValueError("max_size cannot be less than min_size")
+
+    def has_openings(self) -> bool:
+        """Return True if the committee can accept additional members."""
+        return len(self.members) < self.max_size
+
+    def add_member(self, person: Person) -> None:
+        if person in self.exclusions:
+            raise ValueError(f"{person.name} is excluded from this committee")
+        if not self.has_openings():
+            raise ValueError("Committee is already at maximum size")
+        if person in self.members:
+            raise ValueError(f"{person.name} is already a member")
+        if not person.is_available():
+            raise ValueError(f"{person.name} is not available")
+        self.members.add(person)
+        person.assignments.add(self.name)
+
+    def current_coverage(self) -> Set[str]:
+        """Return the set of competencies covered by current members."""
+        coverage: Set[str] = set()
+        for member in self.members:
+            coverage.update(member.competencies)
+        return coverage
+
+    def needs_competency(self, competency: str) -> bool:
+        """Return True if the committee lacks a required competency."""
+        return (
+            competency in self.required_competencies
+            and competency not in self.current_coverage()
+        )

--- a/committee_manager/models/person.py
+++ b/committee_manager/models/person.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Set
+
+
+@dataclass
+class Person:
+    """Represents an individual available for committee service."""
+
+    name: str
+    service_cap: int = 0
+    competencies: Set[str] = field(default_factory=set)
+    assignments: Set[str] = field(default_factory=set)
+
+    def __post_init__(self) -> None:
+        if self.service_cap < 0:
+            raise ValueError("service_cap must be non-negative")
+
+    def workload(self) -> int:
+        """Return the number of committees this person currently serves on."""
+        return len(self.assignments)
+
+    def has_competency(self, competency: str) -> bool:
+        """Return whether the person possesses a given competency."""
+        return competency in self.competencies
+
+    def is_available(self) -> bool:
+        """Return True if the person can accept additional assignments."""
+        return self.workload() < self.service_cap


### PR DESCRIPTION
## Summary
- implement Person model tracking competencies and workload
- create Committee model with membership rules and coverage helpers
- expose new models in package

## Testing
- `python -m pytest`
- `python -m compileall committee_manager`


------
https://chatgpt.com/codex/tasks/task_e_68bec809012883228d11a0170a6ebadd