### PR TITLE
Add CSV/YAML loaders with validation

### DIFF
--- a/committee_manager/io/__init__.py
+++ b/committee_manager/io/__init__.py
@@ -1,0 +1,12 @@
+"""Input/output helpers for :mod:`committee_manager`."""
+
+from .people_loader import load_people
+from .committee_loader import load_committees
+from .rule_loader import load_rules, RuleDefinition
+
+__all__ = [
+    "load_people",
+    "load_committees",
+    "load_rules",
+    "RuleDefinition",
+]

--- a/committee_manager/io/committee_loader.py
+++ b/committee_manager/io/committee_loader.py
@@ -1,0 +1,130 @@
+"""Utilities for loading :class:`~committee_manager.models.committee.Committee` objects from CSV files."""
+from __future__ import annotations
+
+import csv
+import json
+from typing import Dict, Set
+
+from ..models.committee import Committee
+from ..models.person import Person
+
+
+def load_committees(path: str, people: Dict[str, Person] | None = None) -> Dict[str, Committee]:
+    """Load committees from a CSV file.
+
+    The CSV must include ``name``, ``min_size`` and ``max_size`` columns. Optional
+    columns are ``required_competencies``, ``exclusions`` and ``diversity_targets``.
+    Competencies and exclusions should be semicolon-delimited strings. Diversity
+    targets can either be a JSON object or a semicolon-separated list of
+    ``key=value`` pairs.
+
+    Parameters
+    ----------
+    path:
+        Path to the CSV file.
+    people:
+        Optional mapping of person names to :class:`Person` instances. Required if
+        the ``exclusions`` column is used.
+
+    Returns
+    -------
+    dict[str, Committee]
+        Mapping of committee name to :class:`Committee` instances.
+
+    Raises
+    ------
+    ValueError
+        If required columns are missing, referenced people are unknown or data is
+        otherwise invalid.
+    """
+
+    with open(path, newline="") as handle:
+        reader = csv.DictReader(handle)
+        fieldnames = reader.fieldnames or []
+        required = {"name", "min_size", "max_size"}
+        missing = required - set(fieldnames)
+        if missing:
+            raise ValueError(f"Missing required columns: {', '.join(sorted(missing))}")
+
+        committees: Dict[str, Committee] = {}
+        for lineno, row in enumerate(reader, start=2):
+            name = row.get("name", "").strip()
+            if not name:
+                raise ValueError(f"Row {lineno}: 'name' is required")
+
+            try:
+                min_size = int(row.get("min_size", ""))
+                max_size = int(row.get("max_size", ""))
+            except ValueError as exc:
+                raise ValueError(
+                    f"Row {lineno}: min_size and max_size must be integers"
+                ) from exc
+            if min_size < 0 or max_size < 0:
+                raise ValueError(f"Row {lineno}: sizes must be non-negative")
+            if max_size < min_size:
+                raise ValueError(
+                    f"Row {lineno}: max_size cannot be less than min_size"
+                )
+
+            rc_field = row.get("required_competencies", "").strip()
+            required_competencies = {c.strip() for c in rc_field.split(";") if c.strip()}
+
+            exclusions_field = row.get("exclusions", "").strip()
+            exclusions: Set[Person] = set()
+            if exclusions_field:
+                if people is None:
+                    raise ValueError(
+                        f"Row {lineno}: exclusions specified but no people mapping provided"
+                    )
+                for pname in exclusions_field.split(";"):
+                    pname = pname.strip()
+                    if not pname:
+                        continue
+                    person = people.get(pname)
+                    if person is None:
+                        raise ValueError(
+                            f"Row {lineno}: exclusion '{pname}' not found in people list"
+                        )
+                    exclusions.add(person)
+
+            div_field = row.get("diversity_targets", "").strip()
+            diversity_targets: Dict[str, int] = {}
+            if div_field:
+                parsed = False
+                # First try JSON
+                try:
+                    data = json.loads(div_field)
+                    if isinstance(data, dict):
+                        for k, v in data.items():
+                            if not isinstance(v, int):
+                                raise ValueError
+                        diversity_targets = data
+                        parsed = True
+                except (ValueError, json.JSONDecodeError):
+                    pass
+                if not parsed:
+                    pairs = [p for p in div_field.split(";") if p.strip()]
+                    for p in pairs:
+                        if "=" not in p:
+                            raise ValueError(
+                                f"Row {lineno}: diversity_targets entry '{p}' missing '='"
+                            )
+                        k, v = p.split("=", 1)
+                        k = k.strip()
+                        try:
+                            diversity_targets[k] = int(v)
+                        except ValueError as exc:
+                            raise ValueError(
+                                f"Row {lineno}: diversity_targets value '{v}' for key '{k}' must be int"
+                            ) from exc
+
+            committees[name] = Committee(
+                name=name,
+                min_size=min_size,
+                max_size=max_size,
+                required_competencies=required_competencies,
+                exclusions=exclusions,
+                diversity_targets=diversity_targets,
+            )
+
+    return committees

--- a/committee_manager/io/people_loader.py
+++ b/committee_manager/io/people_loader.py
@@ -1,0 +1,64 @@
+"""Utilities for loading :class:`~committee_manager.models.person.Person` objects from CSV files."""
+from __future__ import annotations
+
+import csv
+from typing import Dict
+
+from ..models.person import Person
+
+
+def load_people(path: str) -> Dict[str, Person]:
+    """Load people from a CSV file.
+
+    The CSV is expected to contain at least a ``name`` column. Optional columns
+    are ``service_cap`` and ``competencies``. Competencies should be provided as
+    a semicolon-delimited string.
+
+    Parameters
+    ----------
+    path:
+        Path to the CSV file.
+
+    Returns
+    -------
+    dict[str, Person]
+        Mapping of person name to :class:`Person` instances.
+
+    Raises
+    ------
+    ValueError
+        If required columns are missing or data is invalid.
+    """
+
+    with open(path, newline="") as handle:
+        reader = csv.DictReader(handle)
+        fieldnames = reader.fieldnames or []
+        required = {"name"}
+        missing = required - set(fieldnames)
+        if missing:
+            raise ValueError(f"Missing required columns: {', '.join(sorted(missing))}")
+
+        people: Dict[str, Person] = {}
+        for lineno, row in enumerate(reader, start=2):
+            name = row.get("name", "").strip()
+            if not name:
+                raise ValueError(f"Row {lineno}: 'name' is required")
+
+            service_cap_raw = row.get("service_cap", "0").strip() or "0"
+            try:
+                service_cap = int(service_cap_raw)
+            except ValueError as exc:
+                raise ValueError(
+                    f"Row {lineno}: service_cap must be an integer"
+                ) from exc
+            if service_cap < 0:
+                raise ValueError(f"Row {lineno}: service_cap must be non-negative")
+
+            comp_field = row.get("competencies", "").strip()
+            competencies = {c.strip() for c in comp_field.split(";") if c.strip()}
+
+            people[name] = Person(
+                name=name, service_cap=service_cap, competencies=competencies
+            )
+
+    return people

--- a/committee_manager/io/rule_loader.py
+++ b/committee_manager/io/rule_loader.py
@@ -1,0 +1,83 @@
+"""Load and validate rule definitions from YAML files."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Literal, Optional
+
+import yaml
+
+
+@dataclass
+class RuleDefinition:
+    """Data representation of a rule definition."""
+
+    name: str
+    kind: Literal["hard", "soft"]
+    priority: int
+    applies_to: List[str] = field(default_factory=list)
+    params: Dict[str, Any] = field(default_factory=dict)
+    weight: Optional[float] = None
+    explain_exclude: Optional[str] = None
+    explain_score: Optional[str] = None
+
+
+def _validate_rule(index: int, data: Dict[str, Any]) -> RuleDefinition:
+    required = {"name", "kind", "priority", "params"}
+    missing = required - data.keys()
+    if missing:
+        raise ValueError(
+            f"Rule {index}: missing required fields: {', '.join(sorted(missing))}"
+        )
+
+    name = data["name"]
+    kind = data["kind"]
+    if kind not in {"hard", "soft"}:
+        raise ValueError(f"Rule {index}: kind must be 'hard' or 'soft'")
+
+    priority = data["priority"]
+    if not isinstance(priority, int):
+        raise ValueError(f"Rule {index}: priority must be an integer")
+
+    params = data["params"]
+    if not isinstance(params, dict):
+        raise ValueError(f"Rule {index}: params must be a mapping")
+
+    applies_to = data.get("applies_to") or []
+    if not isinstance(applies_to, list):
+        raise ValueError(f"Rule {index}: applies_to must be a list if provided")
+
+    weight = data.get("weight")
+    if kind == "soft" and weight is None:
+        raise ValueError(f"Rule {index}: soft rules require a weight")
+    if weight is not None and not isinstance(weight, (int, float)):
+        raise ValueError(f"Rule {index}: weight must be a number if provided")
+
+    return RuleDefinition(
+        name=name,
+        kind=kind,
+        priority=priority,
+        applies_to=applies_to,
+        params=params,
+        weight=float(weight) if weight is not None else None,
+        explain_exclude=data.get("explain_exclude"),
+        explain_score=data.get("explain_score"),
+    )
+
+
+def load_rules(path: str) -> List[RuleDefinition]:
+    """Parse a YAML file into :class:`RuleDefinition` objects."""
+    with open(path, "r", encoding="utf8") as handle:
+        data = yaml.safe_load(handle)
+
+    if not isinstance(data, list):
+        raise ValueError("Rule file must contain a list of rule definitions")
+
+    rules: List[RuleDefinition] = []
+    for idx, item in enumerate(data, start=1):
+        if not isinstance(item, dict):
+            raise ValueError(
+                f"Rule {idx}: expected mapping but found {type(item).__name__}"
+            )
+        rules.append(_validate_rule(idx, item))
+
+    return rules

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,4 +10,4 @@ readme = "README.md"
 requires-python = ">=3.8"
 license = {text = "MIT"}
 authors = [{name = "Example Author", email = "author@example.com"}]
-dependencies = []
+dependencies = ["PyYAML"]


### PR DESCRIPTION
## Summary
- implement people and committee CSV loaders with validation
- add rule loader to parse YAML rule definitions
- declare PyYAML dependency

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bec92a810883229147b8b2919cec4f