### PR TITLE
Implement rule evaluation framework

### DIFF
--- a/committee_manager/io/__init__.py
+++ b/committee_manager/io/__init__.py
@@ -2,11 +2,12 @@
 
 from .people_loader import load_people
 from .committee_loader import load_committees
-from .rule_loader import load_rules, RuleDefinition
+from .rule_loader import load_rule_objects, load_rules, RuleDefinition
 
 __all__ = [
     "load_people",
     "load_committees",
+    "load_rule_objects",
     "load_rules",
     "RuleDefinition",
 ]

--- a/committee_manager/io/rule_loader.py
+++ b/committee_manager/io/rule_loader.py
@@ -6,6 +6,8 @@ from typing import Any, Dict, List, Literal, Optional
 
 import yaml
 
+from committee_manager.rules import Rule, build_rules
+
 
 @dataclass
 class RuleDefinition:
@@ -81,3 +83,9 @@ def load_rules(path: str) -> List[RuleDefinition]:
         rules.append(_validate_rule(idx, item))
 
     return rules
+
+
+def load_rule_objects(path: str) -> List[Rule]:
+    """Load rule objects from a YAML file."""
+    definitions = load_rules(path)
+    return build_rules(definitions)

--- a/committee_manager/rules/__init__.py
+++ b/committee_manager/rules/__init__.py
@@ -1,1 +1,53 @@
 """Business rules for committee_manager."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Dict, List, Type
+
+from .base import HardRule, Rule, SoftRule
+from .library import HasCompetencyRule, ServiceCapRule
+
+if TYPE_CHECKING:  # pragma: no cover - for type checkers only
+    from committee_manager.io.rule_loader import RuleDefinition
+
+
+RULE_REGISTRY: Dict[str, Type[Rule]] = {
+    ServiceCapRule.slug: ServiceCapRule,
+    HasCompetencyRule.slug: HasCompetencyRule,
+}
+
+
+def create_rule(defn: "RuleDefinition") -> Rule:
+    """Instantiate a concrete :class:`Rule` from a :class:`RuleDefinition`."""
+    cls = RULE_REGISTRY.get(defn.name)
+    if cls is None:
+        raise KeyError(f"Unknown rule: {defn.name}")
+
+    kwargs = {
+        "name": defn.name,
+        "priority": defn.priority,
+        "applies_to": defn.applies_to,
+        "params": defn.params,
+        "explain_exclude": defn.explain_exclude,
+        "explain_score": defn.explain_score,
+    }
+    if issubclass(cls, SoftRule):
+        kwargs["weight"] = defn.weight if defn.weight is not None else 1.0
+    rule = cls(**kwargs)  # type: ignore[arg-type]
+    return rule
+
+
+def build_rules(definitions: List["RuleDefinition"]) -> List[Rule]:
+    """Build and sort rule objects from definitions."""
+    rules = [create_rule(d) for d in definitions]
+    return sorted(rules, key=lambda r: r.priority)
+
+
+__all__ = [
+    "Rule",
+    "HardRule",
+    "SoftRule",
+    "ServiceCapRule",
+    "HasCompetencyRule",
+    "create_rule",
+    "build_rules",
+]

--- a/committee_manager/rules/base.py
+++ b/committee_manager/rules/base.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Dict, Sequence, Tuple
+
+from committee_manager.models.committee import Committee
+from committee_manager.models.person import Person
+
+
+@dataclass
+class Rule(ABC):
+    """Base class for all business rules."""
+
+    name: str
+    priority: int
+    applies_to: Sequence[str] = field(default_factory=list)
+    params: Dict[str, Any] = field(default_factory=dict)
+    explain_exclude: str | None = None
+    explain_score: str | None = None
+
+    def applies(self, committee: Committee) -> bool:
+        """Return ``True`` if this rule applies to the given committee."""
+        return not self.applies_to or committee.name in self.applies_to
+
+    @abstractmethod
+    def evaluate(
+        self, person: Person, committee: Committee
+    ) -> Tuple[Any, str]:
+        """Evaluate the rule for a person/committee pair."""
+
+
+@dataclass
+class HardRule(Rule):
+    """Rule that determines eligibility."""
+
+    def evaluate(self, person: Person, committee: Committee) -> Tuple[bool, str]:
+        eligible = self.check(person, committee)
+        rationale = ""
+        if not eligible:
+            template = (
+                self.explain_exclude
+                or f"{person.name} excluded by {self.name}"
+            )
+            rationale = template.format(
+                person=person, committee=committee, params=self.params
+            )
+        return eligible, rationale
+
+    @abstractmethod
+    def check(self, person: Person, committee: Committee) -> bool:
+        """Return ``True`` if the person is eligible for the committee."""
+
+
+@dataclass
+class SoftRule(Rule):
+    """Rule that contributes a score."""
+
+    weight: float = 1.0
+
+    def evaluate(self, person: Person, committee: Committee) -> Tuple[float, str]:
+        base = self.score(person, committee)
+        score = base * self.weight
+        template = self.explain_score or f"{self.name} score {score:.2f}"
+        rationale = template.format(
+            person=person,
+            committee=committee,
+            score=score,
+            params=self.params,
+        )
+        return score, rationale
+
+    @abstractmethod
+    def score(self, person: Person, committee: Committee) -> float:
+        """Return a base score for the person/committee pair."""

--- a/committee_manager/rules/library.py
+++ b/committee_manager/rules/library.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from committee_manager.models.committee import Committee
+from committee_manager.models.person import Person
+
+from .base import HardRule, SoftRule
+
+
+@dataclass
+class ServiceCapRule(HardRule):
+    """Disallow assignments beyond a person's service cap."""
+
+    slug = "service_cap"
+
+    def check(self, person: Person, committee: Committee) -> bool:
+        return person.is_available()
+
+
+@dataclass
+class HasCompetencyRule(SoftRule):
+    """Award points if the person possesses a given competency."""
+
+    slug = "has_competency"
+
+    def score(self, person: Person, committee: Committee) -> float:
+        competency = self.params.get("competency")
+        if competency and person.has_competency(competency):
+            return 1.0
+        return 0.0

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1,0 +1,48 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from committee_manager.io import load_rule_objects
+from committee_manager.models.committee import Committee
+from committee_manager.models.person import Person
+from committee_manager.rules import HardRule, SoftRule
+
+
+def test_rule_evaluation(tmp_path):
+    rule_file = tmp_path / "rules.yaml"
+    rule_file.write_text(
+        """
+- name: service_cap
+  kind: hard
+  priority: 1
+  params: {}
+  explain_exclude: "{person.name} is at capacity"
+- name: has_competency
+  kind: soft
+  priority: 2
+  weight: 1.5
+  params:
+    competency: finance
+  explain_score: "{person.name} adds {params[competency]} skill"
+""",
+        encoding="utf8",
+    )
+
+    rules = load_rule_objects(str(rule_file))
+    assert len(rules) == 2
+    assert [r.priority for r in rules] == [1, 2]
+
+    person = Person(name="Alice", service_cap=1, competencies={"finance"})
+    committee = Committee(name="Finance", min_size=1, max_size=5)
+
+    person.assignments.add("Existing")
+    hard = next(r for r in rules if isinstance(r, HardRule))
+    eligible, rationale = hard.evaluate(person, committee)
+    assert not eligible
+    assert "capacity" in rationale
+
+    soft = next(r for r in rules if isinstance(r, SoftRule))
+    score, rationale = soft.evaluate(person, committee)
+    assert score == 1.5
+    assert "finance" in rationale


### PR DESCRIPTION
## Summary
- add abstract Rule/HardRule/SoftRule classes with rationale-producing evaluations
- implement ServiceCapRule and HasCompetencyRule plus registry and YAML mapping
- expose rule loading from YAML to concrete rule objects

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68beca2780b08322b000c9dc378962b3