### PR TITLE
Add reporting utilities for allocation rationales

### DIFF
--- a/committee_manager/reporting/__init__.py
+++ b/committee_manager/reporting/__init__.py
@@ -1,0 +1,9 @@
+"""Reporting utilities for committee_manager."""
+
+from .rationale import (
+    format_seat_rationales,
+    export_yaml,
+    export_csv,
+)
+
+__all__ = ["format_seat_rationales", "export_yaml", "export_csv"]

--- a/committee_manager/reporting/rationale.py
+++ b/committee_manager/reporting/rationale.py
@@ -1,0 +1,105 @@
+"""Utilities for exporting allocation rationales and committee health.
+
+This module provides functions to transform an
+:class:`~committee_manager.engine.allocator.AllocationResult` into
+structures suitable for YAML or CSV output.  Seat rationales are grouped
+by committee and person, and health metrics summarize overall committee
+status.
+"""
+from __future__ import annotations
+
+import csv
+from typing import Dict, Tuple
+
+import yaml
+
+from ..engine.allocator import AllocationResult
+
+
+def format_seat_rationales(result: AllocationResult) -> Dict[str, Dict[str, str]]:
+    """Return seat rationales grouped by committee and person.
+
+    Parameters
+    ----------
+    result:
+        Allocation result containing rationales keyed by ``(committee, person)``.
+
+    Returns
+    -------
+    dict[str, dict[str, str]]
+        Mapping of committee name -> person name -> rationale string.
+    """
+    grouped: Dict[str, Dict[str, str]] = {}
+    for (committee, person), rationale in sorted(result.rationales.items()):
+        grouped.setdefault(committee, {})[person] = rationale
+    return grouped
+
+
+def export_yaml(result: AllocationResult, allocation_file: str, rationale_file: str) -> None:
+    """Write allocation and rationale data to YAML files.
+
+    The allocation file maps each committee to a list of member names. The
+    rationale file contains per-seat rationales and committee health metrics.
+
+    Parameters
+    ----------
+    result:
+        Allocation package produced by the allocator.
+    allocation_file:
+        Path to write committee membership YAML.
+    rationale_file:
+        Path to write rationales + health YAML.
+    """
+    allocations = {
+        committee.name: [person.name for person in sorted(committee.members, key=lambda p: p.name)]
+        for committee in sorted(result.committees, key=lambda c: c.name)
+    }
+    rationales = {
+        "seats": format_seat_rationales(result),
+        "committee_health": result.committee_health,
+    }
+    with open(allocation_file, "w", encoding="utf8") as handle:
+        yaml.safe_dump(allocations, handle, sort_keys=True)
+    with open(rationale_file, "w", encoding="utf8") as handle:
+        yaml.safe_dump(rationales, handle, sort_keys=True)
+
+
+def export_csv(result: AllocationResult, allocation_file: str, rationale_file: str) -> None:
+    """Write allocation and rationale data to CSV files.
+
+    The allocation CSV has columns ``committee`` and ``person``. The
+    rationale CSV first lists seat rationales with columns ``committee``,
+    ``person`` and ``rationale``. After a blank row a second header is
+    written containing committee health metrics.
+    """
+    allocation_rows = []
+    for committee in sorted(result.committees, key=lambda c: c.name):
+        for person in sorted(committee.members, key=lambda p: p.name):
+            allocation_rows.append({"committee": committee.name, "person": person.name})
+    with open(allocation_file, "w", newline="", encoding="utf8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=["committee", "person"])
+        writer.writeheader()
+        writer.writerows(allocation_rows)
+
+    seat_rationales = format_seat_rationales(result)
+    with open(rationale_file, "w", newline="", encoding="utf8") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(["committee", "person", "rationale"])
+        for committee in sorted(seat_rationales):
+            people = seat_rationales[committee]
+            for person in sorted(people):
+                writer.writerow([committee, person, people[person]])
+        writer.writerow([])
+        writer.writerow(["committee", "size", "min_size", "max_size", "missing_competencies"])
+        for committee in sorted(result.committee_health):
+            metrics = result.committee_health[committee]
+            missing = ";".join(sorted(metrics.get("missing_competencies", [])))
+            writer.writerow(
+                [
+                    committee,
+                    metrics.get("size"),
+                    metrics.get("min_size"),
+                    metrics.get("max_size"),
+                    missing,
+                ]
+            )

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,0 +1,90 @@
+import csv
+import sys
+from pathlib import Path
+
+import yaml
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from committee_manager.engine.allocator import AllocationResult
+from committee_manager.models.person import Person
+from committee_manager.models.committee import Committee
+from committee_manager.rules.base import HardRule, SoftRule
+from committee_manager.reporting import export_yaml, export_csv
+
+Person.__hash__ = object.__hash__
+
+
+class CapacityRule(HardRule):
+    def check(self, person: Person, committee: Committee) -> bool:  # pragma: no cover - simple pass-through
+        return person.is_available()
+
+
+class CompetencyRule(SoftRule):
+    def score(self, person: Person, committee: Committee) -> float:  # pragma: no cover - simple pass-through
+        return 1.0 if self.params["competency"] in person.competencies else 0.0
+
+
+def test_export_yaml_and_csv(tmp_path):
+    alice = Person(name="Alice", service_cap=2, competencies={"finance"})
+    bob = Person(name="Bob", service_cap=1)
+    bob.assignments.add("Existing")  # at capacity
+
+    committee = Committee(name="Finance", min_size=1, max_size=5)
+    committee.add_member(alice)
+
+    hard = CapacityRule(name="service_cap", priority=1, explain_exclude="{person.name} is at capacity")
+    soft = CompetencyRule(
+        name="has_competency",
+        priority=2,
+        weight=1.5,
+        params={"competency": "finance"},
+        explain_score="{person.name} adds {params[competency]} skill",
+    )
+
+    _, exclude_rationale = hard.evaluate(bob, committee)
+    _, include_rationale = soft.evaluate(alice, committee)
+
+    result = AllocationResult(
+        committees=[committee],
+        rationales={
+            (committee.name, alice.name): include_rationale,
+            (committee.name, bob.name): exclude_rationale,
+        },
+        committee_health={
+            committee.name: {
+                "size": 1,
+                "min_size": 1,
+                "max_size": 5,
+                "missing_competencies": [],
+            }
+        },
+    )
+
+    alloc_yaml = tmp_path / "alloc.yaml"
+    rat_yaml = tmp_path / "rationale.yaml"
+    export_yaml(result, str(alloc_yaml), str(rat_yaml))
+
+    allocations = yaml.safe_load(alloc_yaml.read_text())
+    assert allocations == {"Finance": ["Alice"]}
+
+    rationale_data = yaml.safe_load(rat_yaml.read_text())
+    assert rationale_data["seats"]["Finance"]["Alice"] == include_rationale
+    assert rationale_data["seats"]["Finance"]["Bob"] == exclude_rationale
+    assert rationale_data["committee_health"]["Finance"]["size"] == 1
+
+    alloc_csv = tmp_path / "alloc.csv"
+    rat_csv = tmp_path / "rationale.csv"
+    export_csv(result, str(alloc_csv), str(rat_csv))
+
+    with open(alloc_csv, newline="", encoding="utf8") as handle:
+        rows = list(csv.DictReader(handle))
+    assert rows == [{"committee": "Finance", "person": "Alice"}]
+
+    with open(rat_csv, newline="", encoding="utf8") as handle:
+        rows = list(csv.reader(handle))
+    assert rows[0] == ["committee", "person", "rationale"]
+    assert ["Finance", "Alice", include_rationale] in rows
+    assert ["Finance", "Bob", exclude_rationale] in rows
+    header_idx = rows.index(["committee", "size", "min_size", "max_size", "missing_competencies"])
+    assert rows[header_idx + 1][:4] == ["Finance", "1", "1", "5"]


### PR DESCRIPTION
## Summary
- add `reporting` module to export seat rationales and committee health
- support YAML/CSV outputs for allocations and rationales
- test rationale export using rule templates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68becd542c708322b122315d01daea8d