### PR TITLE
Use identity hashing for Person dataclass

### DIFF
--- a/committee_manager/models/person.py
+++ b/committee_manager/models/person.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from typing import Set
 
 
-@dataclass
+@dataclass(eq=False)
 class Person:
     """Represents an individual available for committee service."""
 

--- a/tests/test_allocator.py
+++ b/tests/test_allocator.py
@@ -9,9 +9,6 @@ from committee_manager.engine.allocator import Allocator
 from committee_manager.models.person import Person
 from committee_manager.models.committee import Committee
 
-# Ensure hashability for set operations
-Person.__hash__ = object.__hash__
-
 
 def test_precheck_feasibility_errors():
     alice = Person(name="Alice", service_cap=0)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -8,9 +8,6 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from committee_manager.models.person import Person
 from committee_manager.models.committee import Committee
 
-# Make Person hashable for set membership
-Person.__hash__ = object.__hash__
-
 
 def test_person_service_cap_validation():
     with pytest.raises(ValueError):
@@ -43,3 +40,12 @@ def test_committee_add_member_validations():
     # No remaining openings
     with pytest.raises(ValueError):
         committee.add_member(Person(name="Carol", service_cap=1))
+
+
+def test_committee_add_member_without_hash_patch():
+    """Regression test ensuring Person is hashable by default."""
+    alice = Person(name="Alice", service_cap=1)
+    committee = Committee(name="Finance", min_size=0, max_size=1)
+    committee.add_member(alice)
+    assert committee.members == {alice}
+    assert alice.assignments == {"Finance"}

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -12,8 +12,6 @@ from committee_manager.models.committee import Committee
 from committee_manager.rules.base import HardRule, SoftRule
 from committee_manager.reporting import export_yaml, export_csv
 
-Person.__hash__ = object.__hash__
-
 
 class CapacityRule(HardRule):
     def check(self, person: Person, committee: Committee) -> bool:  # pragma: no cover - simple pass-through


### PR DESCRIPTION
## Summary
- Make `Person` dataclass rely on object identity for hashing
- Remove test monkey patches for `Person.__hash__`
- Add regression test ensuring `Committee.add_member` works without patching

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bed719d9d08322afc5d6924317d787