### PR TITLE
Add sample data and CLI integration test

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,43 +25,60 @@ pip install -e .
 pytest
 ```
 
+
 ### Sample Data
+
+Sample CSV and YAML files are provided in the `examples/` directory:
 
 **people.csv**
 
-```
+```csv
 name,service_cap,competencies
 Alice,2,finance;strategy
 Bob,1,
+Carol,1,strategy
+Dave,1,finance
 ```
 
 **committees.csv**
 
-```
+```csv
 name,min_size,max_size,required_competencies
 Finance,1,2,finance
+Strategy,1,2,strategy
+Operations,1,1,
 ```
 
 **rules.yaml**
 
-```
+```yaml
 - name: service_cap
   kind: hard
   priority: 1
   params: {}
   explain_exclude: "{person.name} is at capacity"
+- name: has_competency
+  kind: soft
+  priority: 2
+  weight: 1
+  params:
+    competency: finance
+  explain_score: "{person.name} has finance competency"
+- name: has_competency
+  kind: soft
+  priority: 2
+  weight: 1
+  params:
+    competency: strategy
+  explain_score: "{person.name} has strategy competency"
 ```
 
 ### CLI Usage
 
-Run the allocator over the data files:
+Run the allocator over the sample files:
 
 ```bash
-python -m committee_manager.cli.main allocate \
-    --people people.csv \
-    --committees committees.csv \
-    --rules rules.yaml \
-    --output output_dir
+python -m committee_manager.cli.main allocate --people examples/people.csv --committees examples/committees.csv --rules examples/rules.yaml --output output_dir
 ```
 
 The command writes `allocation.yaml` and `rationale.yaml` to `output_dir`.

--- a/examples/committees.csv
+++ b/examples/committees.csv
@@ -1,0 +1,4 @@
+name,min_size,max_size,required_competencies
+Finance,1,2,finance
+Strategy,1,2,strategy
+Operations,1,1,

--- a/examples/people.csv
+++ b/examples/people.csv
@@ -1,0 +1,5 @@
+name,service_cap,competencies
+Alice,2,finance;strategy
+Bob,1,
+Carol,1,strategy
+Dave,1,finance

--- a/examples/rules.yaml
+++ b/examples/rules.yaml
@@ -1,0 +1,19 @@
+- name: service_cap
+  kind: hard
+  priority: 1
+  params: {}
+  explain_exclude: "{person.name} is at capacity"
+- name: has_competency
+  kind: soft
+  priority: 2
+  weight: 1
+  params:
+    competency: finance
+  explain_score: "{person.name} has finance competency"
+- name: has_competency
+  kind: soft
+  priority: 2
+  weight: 1
+  params:
+    competency: strategy
+  explain_score: "{person.name} has strategy competency"

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+import argparse
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from committee_manager.cli.main import cmd_allocate
+
+
+def test_allocate_examples(tmp_path):
+    root = Path(__file__).resolve().parents[1]
+    output_dir = tmp_path / "out"
+    args = argparse.Namespace(
+        people=root / "examples/people.csv",
+        committees=root / "examples/committees.csv",
+        rules=root / "examples/rules.yaml",
+        scenario=None,
+        output=str(output_dir),
+        format="yaml",
+    )
+    cmd_allocate(args)
+    assert (output_dir / "allocation.yaml").exists()
+    assert (output_dir / "rationale.yaml").exists()


### PR DESCRIPTION
## Summary
- add `examples` directory with sample people, committee, and rule files
- document using the example data in the README
- add integration test that runs the allocator over the example files

## Testing
- `pytest -q`
- `python -m committee_manager.cli.main allocate --people examples/people.csv --committees examples/committees.csv --rules examples/rules.yaml --output /tmp/out`


------
https://chatgpt.com/codex/tasks/task_e_68bed7fbc60483228d466af211d2bb5c