### PR TITLE
Add simple web interface for committee allocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,16 @@ python -m committee_manager.cli.main allocate --people examples/people.csv --com
 
 The command writes `allocation.yaml` and `rationale.yaml` to `output_dir`.
 
+### Web Application
+
+Run a minimal web interface for uploading input files and viewing the resulting allocation:
+
+```bash
+python -m committee_manager.web.app
+```
+
+Visit <http://localhost:5000/> in a browser and upload your CSV/YAML files to generate an allocation.
+
 ---
 
 ## 1. Scope & Philosophy

--- a/committee_manager/web/__init__.py
+++ b/committee_manager/web/__init__.py
@@ -1,0 +1,6 @@
+"""Simple Flask-based web interface for committee allocation."""
+from __future__ import annotations
+
+from .app import app, create_app
+
+__all__ = ["app", "create_app"]

--- a/committee_manager/web/app.py
+++ b/committee_manager/web/app.py
@@ -1,0 +1,97 @@
+"""Minimal Flask application exposing the allocator via a web form."""
+from __future__ import annotations
+
+import os
+import tempfile
+from typing import Dict, List
+
+from flask import Flask, render_template_string, request
+
+from ..engine.allocator import Allocator
+from ..io.committee_loader import load_committees
+from ..io.people_loader import load_people
+from ..io.rule_loader import load_rule_objects
+from ..reporting.rationale import export_yaml
+
+app = Flask(__name__)
+
+FORM_TEMPLATE = """
+<!doctype html>
+<title>Committee Manager</title>
+<h1>Upload allocation inputs</h1>
+<form method=post enctype=multipart/form-data>
+  <label>People CSV: <input type=file name=people required></label><br>
+  <label>Committees CSV: <input type=file name=committees required></label><br>
+  <label>Rules YAML: <input type=file name=rules></label><br>
+  <input type=submit value="Allocate">
+</form>
+"""
+
+RESULT_TEMPLATE = """
+<!doctype html>
+<title>Allocation Result</title>
+<h1>Allocation</h1>
+<pre>{{ allocation }}</pre>
+<h1>Rationale</h1>
+<pre>{{ rationale }}</pre>
+<p><a href="/">Back</a></p>
+"""
+
+
+@app.route("/", methods=["GET", "POST"])
+def allocate() -> str:
+    """Render upload form or process allocation request."""
+    if request.method == "POST":
+        people_file = request.files.get("people")
+        committees_file = request.files.get("committees")
+        rules_file = request.files.get("rules")
+        if not people_file or not committees_file:
+            return "People and committees files are required", 400
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            people_path = os.path.join(tmpdir, "people.csv")
+            committees_path = os.path.join(tmpdir, "committees.csv")
+            rules_path = os.path.join(tmpdir, "rules.yaml")
+            people_file.save(people_path)
+            committees_file.save(committees_path)
+            if rules_file and rules_file.filename:
+                rules_file.save(rules_path)
+            else:
+                rules_path = None
+
+            people = load_people(people_path)
+            committees = load_committees(committees_path, people)
+            rules = load_rule_objects(rules_path) if rules_path else []
+
+            committees_list: List = list(committees.values())
+            people_list: List = list(people.values())
+            rationales: Dict = {}
+
+            Allocator.precheck_feasibility(committees_list, people_list)
+            Allocator.greedy_fill(committees_list, people_list, rationales)
+            Allocator.local_improvements(committees_list, people_list, rationales)
+            result = Allocator.package_result(committees_list, rationales)
+
+            allocation_file = os.path.join(tmpdir, "allocation.yaml")
+            rationale_file = os.path.join(tmpdir, "rationale.yaml")
+            export_yaml(result, allocation_file, rationale_file)
+
+            with open(allocation_file, "r", encoding="utf8") as handle:
+                allocation = handle.read()
+            with open(rationale_file, "r", encoding="utf8") as handle:
+                rationale = handle.read()
+
+        return render_template_string(
+            RESULT_TEMPLATE, allocation=allocation, rationale=rationale
+        )
+
+    return FORM_TEMPLATE
+
+
+def create_app() -> Flask:
+    """Return the Flask application instance."""
+    return app
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,4 +10,4 @@ readme = "README.md"
 requires-python = ">=3.8"
 license = {text = "MIT"}
 authors = [{name = "Example Author", email = "author@example.com"}]
-dependencies = ["PyYAML"]
+dependencies = ["PyYAML", "Flask"]

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from committee_manager.web import create_app
+
+
+def test_web_allocation(tmp_path):
+    app = create_app()
+    client = app.test_client()
+
+    # Ensure GET works
+    resp = client.get("/")
+    assert resp.status_code == 200
+
+    people_path = tmp_path / "people.csv"
+    committees_path = tmp_path / "committees.csv"
+    rules_path = tmp_path / "rules.yaml"
+
+    people_path.write_text(
+        "name,service_cap,competencies\nAlice,2,finance;strategy\nBob,1,\n"
+    )
+    committees_path.write_text(
+        "name,min_size,max_size,required_competencies\nFinance,1,2,finance\n"
+    )
+    rules_path.write_text(
+        (
+            "- name: has_competency\n  kind: soft\n  priority: 1\n  weight: 1\n  params:\n"
+            "    competency: finance\n  explain_score: '{person.name} has finance competency'\n"
+        )
+    )
+
+    data = {
+        "people": (people_path.open("rb"), "people.csv"),
+        "committees": (committees_path.open("rb"), "committees.csv"),
+        "rules": (rules_path.open("rb"), "rules.yaml"),
+    }
+    resp = client.post("/", data=data, content_type="multipart/form-data")
+    assert resp.status_code == 200
+    assert b"Finance" in resp.data
+    assert b"Alice" in resp.data


### PR DESCRIPTION
## Summary
- add Flask-based web app for uploading input files and viewing allocation results
- document web app usage in README
- include tests for the new web interface

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf18ae4ec08322885d2a118bd5cb83