### PR TITLE
Fix package discovery and ignore build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ __pycache__/
 build/
 develop-eggs/
 dist/
+output_dir/
 downloads/
 eggs/
 .eggs/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,9 @@ version = "0.1.0"
 description = "A package for managing committees."
 readme = "README.md"
 requires-python = ">=3.8"
-license = {text = "MIT"}
+license = "MIT"
 authors = [{name = "Example Author", email = "author@example.com"}]
 dependencies = ["PyYAML", "Flask"]
+
+[tool.setuptools.packages.find]
+include = ["committee_manager*"]


### PR DESCRIPTION
## Summary
- define package discovery to only include `committee_manager`
- switch project license to SPDX string
- ignore `output_dir` build artifact

## Testing
- `pytest`
- `pip install -e .`


------
https://chatgpt.com/codex/tasks/task_e_68bf1a92947883228bfad8ae4785c6f8