### PR TITLE
Allow web app remote access

### DIFF
--- a/committee_manager/web/app.py
+++ b/committee_manager/web/app.py
@@ -94,4 +94,5 @@ def create_app() -> Flask:
 
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    # Bind to all interfaces to allow remote access when running the app directly.
+    app.run(debug=True, host="0.0.0.0")


### PR DESCRIPTION
## Summary
- Bind Flask test app to `0.0.0.0` so it can be reached from remote hosts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf1d6a94b08322836c5defcb4c2c87