### PR TITLE
Add editing of uploaded tables in web app

### DIFF
--- a/committee_manager/web/app.py
+++ b/committee_manager/web/app.py
@@ -23,6 +23,21 @@ FORM_TEMPLATE = """
   <label>People CSV: <input type=file name=people required></label><br>
   <label>Committees CSV: <input type=file name=committees required></label><br>
   <label>Rules YAML: <input type=file name=rules></label><br>
+  <input type=submit value="Upload">
+</form>
+"""
+
+EDIT_TEMPLATE = """
+<!doctype html>
+<title>Edit Inputs</title>
+<h1>Edit People</h1>
+<form method=post>
+  <input type=hidden name="people_path" value="{{ people_path }}">
+  <input type=hidden name="committees_path" value="{{ committees_path }}">
+  <input type=hidden name="rules_path" value="{{ rules_path }}">
+  <textarea name=people_content rows=10 cols=80>{{ people }}</textarea>
+  <h1>Edit Committees</h1>
+  <textarea name=committees_content rows=10 cols=80>{{ committees }}</textarea><br>
   <input type=submit value="Allocate">
 </form>
 """
@@ -40,24 +55,21 @@ RESULT_TEMPLATE = """
 
 @app.route("/", methods=["GET", "POST"])
 def allocate() -> str:
-    """Render upload form or process allocation request."""
+    """Render upload form, edit data, or process allocation request."""
     if request.method == "POST":
-        people_file = request.files.get("people")
-        committees_file = request.files.get("committees")
-        rules_file = request.files.get("rules")
-        if not people_file or not committees_file:
-            return "People and committees files are required", 400
+        # Allocation submission after editing
+        if "people_path" in request.form:
+            people_path = request.form["people_path"]
+            committees_path = request.form["committees_path"]
+            rules_path = request.form.get("rules_path") or None
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            people_path = os.path.join(tmpdir, "people.csv")
-            committees_path = os.path.join(tmpdir, "committees.csv")
-            rules_path = os.path.join(tmpdir, "rules.yaml")
-            people_file.save(people_path)
-            committees_file.save(committees_path)
-            if rules_file and rules_file.filename:
-                rules_file.save(rules_path)
-            else:
-                rules_path = None
+            # Persist edited contents back to their files
+            people_content = request.form.get("people_content", "")
+            committees_content = request.form.get("committees_content", "")
+            with open(people_path, "w", encoding="utf8") as handle:
+                handle.write(people_content.strip() + "\n")
+            with open(committees_path, "w", encoding="utf8") as handle:
+                handle.write(committees_content.strip() + "\n")
 
             people = load_people(people_path)
             committees = load_committees(committees_path, people)
@@ -72,6 +84,7 @@ def allocate() -> str:
             Allocator.local_improvements(committees_list, people_list, rationales)
             result = Allocator.package_result(committees_list, rationales)
 
+            tmpdir = os.path.dirname(people_path)
             allocation_file = os.path.join(tmpdir, "allocation.yaml")
             rationale_file = os.path.join(tmpdir, "rationale.yaml")
             export_yaml(result, allocation_file, rationale_file)
@@ -81,8 +94,40 @@ def allocate() -> str:
             with open(rationale_file, "r", encoding="utf8") as handle:
                 rationale = handle.read()
 
+            return render_template_string(
+                RESULT_TEMPLATE, allocation=allocation, rationale=rationale
+            )
+
+        # Initial upload of files
+        people_file = request.files.get("people")
+        committees_file = request.files.get("committees")
+        rules_file = request.files.get("rules")
+        if not people_file or not committees_file:
+            return "People and committees files are required", 400
+
+        tmpdir = tempfile.mkdtemp()
+        people_path = os.path.join(tmpdir, "people.csv")
+        committees_path = os.path.join(tmpdir, "committees.csv")
+        rules_path = os.path.join(tmpdir, "rules.yaml")
+        people_file.save(people_path)
+        committees_file.save(committees_path)
+        if rules_file and rules_file.filename:
+            rules_file.save(rules_path)
+        else:
+            rules_path = None
+
+        with open(people_path, "r", encoding="utf8") as handle:
+            people_text = handle.read()
+        with open(committees_path, "r", encoding="utf8") as handle:
+            committees_text = handle.read()
+
         return render_template_string(
-            RESULT_TEMPLATE, allocation=allocation, rationale=rationale
+            EDIT_TEMPLATE,
+            people=people_text,
+            committees=committees_text,
+            people_path=people_path,
+            committees_path=committees_path,
+            rules_path=rules_path or "",
         )
 
     return FORM_TEMPLATE

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -28,12 +28,48 @@ def test_web_allocation(tmp_path):
         )
     )
 
-    data = {
+    upload_data = {
         "people": (people_path.open("rb"), "people.csv"),
         "committees": (committees_path.open("rb"), "committees.csv"),
         "rules": (rules_path.open("rb"), "rules.yaml"),
     }
-    resp = client.post("/", data=data, content_type="multipart/form-data")
+    resp = client.post("/", data=upload_data, content_type="multipart/form-data")
+    assert resp.status_code == 200
+    assert b"Edit People" in resp.data
+
+    import re
+
+    people_path_val = re.search(
+        b'name="people_path" value="([^"]+)"', resp.data
+    ).group(1).decode()
+    committees_path_val = re.search(
+        b'name="committees_path" value="([^"]+)"', resp.data
+    ).group(1).decode()
+    rules_path_val = re.search(
+        b'name="rules_path" value="([^"]*)"', resp.data
+    ).group(1).decode()
+
+    people_content = (
+        "name,service_cap,competencies\n"
+        "Alice,2,finance;strategy\n"
+        "Bob,1,\n"
+        "Carol,1,finance\n"
+    )
+    committees_content = (
+        "name,min_size,max_size,required_competencies\n"
+        "Finance,1,2,finance\n"
+    )
+
+    resp = client.post(
+        "/",
+        data={
+            "people_path": people_path_val,
+            "committees_path": committees_path_val,
+            "rules_path": rules_path_val,
+            "people_content": people_content,
+            "committees_content": committees_content,
+        },
+    )
     assert resp.status_code == 200
     assert b"Finance" in resp.data
     assert b"Alice" in resp.data


### PR DESCRIPTION
## Summary
- Allow uploaded people and committees CSVs to be edited before running allocation
- Preserve edits by writing textarea contents back to uploaded files
- Update webapp test to cover new edit workflow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf1f10c79083229357782f117e94e5