### PR TITLE
Load inputs from directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ build/
 develop-eggs/
 dist/
 output_dir/
+inputs/*
+!inputs/.gitkeep
 downloads/
 eggs/
 .eggs/

--- a/README.md
+++ b/README.md
@@ -85,13 +85,15 @@ The command writes `allocation.yaml` and `rationale.yaml` to `output_dir`.
 
 ### Web Application
 
-Run a minimal web interface for uploading input files and viewing the resulting allocation:
+Run a minimal web interface that loads files from the `inputs/` folder and
+shows them for editing before allocation:
 
 ```bash
 python -m committee_manager.web.app
 ```
 
-Visit <http://localhost:5000/> in a browser and upload your CSV/YAML files to generate an allocation.
+Visit <http://localhost:5000/> in a browser to view the files in `inputs/` and
+generate an allocation without uploading.
 
 ---
 

--- a/committee_manager/web/app.py
+++ b/committee_manager/web/app.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import os
-import tempfile
+from pathlib import Path
 from typing import Dict, List
 
 from flask import Flask, render_template_string, request
@@ -15,17 +15,17 @@ from ..reporting.rationale import export_yaml
 
 app = Flask(__name__)
 
-FORM_TEMPLATE = """
-<!doctype html>
-<title>Committee Manager</title>
-<h1>Upload allocation inputs</h1>
-<form method=post enctype=multipart/form-data>
-  <label>People CSV: <input type=file name=people required></label><br>
-  <label>Committees CSV: <input type=file name=committees required></label><br>
-  <label>Rules YAML: <input type=file name=rules></label><br>
-  <input type=submit value="Upload">
-</form>
-"""
+INPUT_DIR = Path(__file__).resolve().parents[2] / "inputs"
+
+
+def _ensure_inputs_populated() -> None:
+    """Create inputs dir and populate with examples if empty."""
+    example_dir = Path(__file__).resolve().parents[2] / "examples"
+    INPUT_DIR.mkdir(exist_ok=True)
+    if not any(INPUT_DIR.iterdir()) and example_dir.exists():
+        for name in example_dir.iterdir():
+            if name.is_file():
+                (INPUT_DIR / name.name).write_text(name.read_text(encoding="utf8"), encoding="utf8")
 
 EDIT_TEMPLATE = """
 <!doctype html>
@@ -55,82 +55,64 @@ RESULT_TEMPLATE = """
 
 @app.route("/", methods=["GET", "POST"])
 def allocate() -> str:
-    """Render upload form, edit data, or process allocation request."""
-    if request.method == "POST":
-        # Allocation submission after editing
-        if "people_path" in request.form:
-            people_path = request.form["people_path"]
-            committees_path = request.form["committees_path"]
-            rules_path = request.form.get("rules_path") or None
+    """Render edit form or process allocation request."""
+    _ensure_inputs_populated()
 
-            # Persist edited contents back to their files
-            people_content = request.form.get("people_content", "")
-            committees_content = request.form.get("committees_content", "")
-            with open(people_path, "w", encoding="utf8") as handle:
-                handle.write(people_content.strip() + "\n")
-            with open(committees_path, "w", encoding="utf8") as handle:
-                handle.write(committees_content.strip() + "\n")
+    if request.method == "POST" and "people_path" in request.form:
+        people_path = request.form["people_path"]
+        committees_path = request.form["committees_path"]
+        rules_path = request.form.get("rules_path") or None
 
-            people = load_people(people_path)
-            committees = load_committees(committees_path, people)
-            rules = load_rule_objects(rules_path) if rules_path else []
+        people_content = request.form.get("people_content", "")
+        committees_content = request.form.get("committees_content", "")
+        with open(people_path, "w", encoding="utf8") as handle:
+            handle.write(people_content.strip() + "\n")
+        with open(committees_path, "w", encoding="utf8") as handle:
+            handle.write(committees_content.strip() + "\n")
 
-            committees_list: List = list(committees.values())
-            people_list: List = list(people.values())
-            rationales: Dict = {}
+        people = load_people(people_path)
+        committees = load_committees(committees_path, people)
+        rules = load_rule_objects(rules_path) if rules_path else []
 
-            Allocator.precheck_feasibility(committees_list, people_list)
-            Allocator.greedy_fill(committees_list, people_list, rationales)
-            Allocator.local_improvements(committees_list, people_list, rationales)
-            result = Allocator.package_result(committees_list, rationales)
+        committees_list: List = list(committees.values())
+        people_list: List = list(people.values())
+        rationales: Dict = {}
 
-            tmpdir = os.path.dirname(people_path)
-            allocation_file = os.path.join(tmpdir, "allocation.yaml")
-            rationale_file = os.path.join(tmpdir, "rationale.yaml")
-            export_yaml(result, allocation_file, rationale_file)
+        Allocator.precheck_feasibility(committees_list, people_list)
+        Allocator.greedy_fill(committees_list, people_list, rationales)
+        Allocator.local_improvements(committees_list, people_list, rationales)
+        result = Allocator.package_result(committees_list, rationales)
 
-            with open(allocation_file, "r", encoding="utf8") as handle:
-                allocation = handle.read()
-            with open(rationale_file, "r", encoding="utf8") as handle:
-                rationale = handle.read()
+        tmpdir = os.path.dirname(people_path)
+        allocation_file = os.path.join(tmpdir, "allocation.yaml")
+        rationale_file = os.path.join(tmpdir, "rationale.yaml")
+        export_yaml(result, allocation_file, rationale_file)
 
-            return render_template_string(
-                RESULT_TEMPLATE, allocation=allocation, rationale=rationale
-            )
-
-        # Initial upload of files
-        people_file = request.files.get("people")
-        committees_file = request.files.get("committees")
-        rules_file = request.files.get("rules")
-        if not people_file or not committees_file:
-            return "People and committees files are required", 400
-
-        tmpdir = tempfile.mkdtemp()
-        people_path = os.path.join(tmpdir, "people.csv")
-        committees_path = os.path.join(tmpdir, "committees.csv")
-        rules_path = os.path.join(tmpdir, "rules.yaml")
-        people_file.save(people_path)
-        committees_file.save(committees_path)
-        if rules_file and rules_file.filename:
-            rules_file.save(rules_path)
-        else:
-            rules_path = None
-
-        with open(people_path, "r", encoding="utf8") as handle:
-            people_text = handle.read()
-        with open(committees_path, "r", encoding="utf8") as handle:
-            committees_text = handle.read()
+        with open(allocation_file, "r", encoding="utf8") as handle:
+            allocation = handle.read()
+        with open(rationale_file, "r", encoding="utf8") as handle:
+            rationale = handle.read()
 
         return render_template_string(
-            EDIT_TEMPLATE,
-            people=people_text,
-            committees=committees_text,
-            people_path=people_path,
-            committees_path=committees_path,
-            rules_path=rules_path or "",
+            RESULT_TEMPLATE, allocation=allocation, rationale=rationale
         )
 
-    return FORM_TEMPLATE
+    people_path = INPUT_DIR / "people.csv"
+    committees_path = INPUT_DIR / "committees.csv"
+    rules_path = INPUT_DIR / "rules.yaml"
+    people_text = people_path.read_text(encoding="utf8") if people_path.exists() else ""
+    committees_text = (
+        committees_path.read_text(encoding="utf8") if committees_path.exists() else ""
+    )
+
+    return render_template_string(
+        EDIT_TEMPLATE,
+        people=people_text,
+        committees=committees_text,
+        people_path=str(people_path),
+        committees_path=str(committees_path),
+        rules_path=str(rules_path) if rules_path.exists() else "",
+    )
 
 
 def create_app() -> Flask:


### PR DESCRIPTION
## Summary
- Serve web app inputs from a local `inputs/` directory and prefill it with example files
- Document new behavior and ignore `inputs/` in version control

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf217d3150832287ea678347814ddc