### PR TITLE
feat: extend Person with demographic fields

### DIFF
--- a/committee_manager/models/person.py
+++ b/committee_manager/models/person.py
@@ -10,12 +10,20 @@ class Person:
 
     name: str
     service_cap: int = 0
+    age: int = 0
+    sex: str = ""
+    family_branch: str = ""
     competencies: Set[str] = field(default_factory=set)
+    interests: Set[str] = field(default_factory=set)
     assignments: Set[str] = field(default_factory=set)
 
     def __post_init__(self) -> None:
         if self.service_cap < 0:
             raise ValueError("service_cap must be non-negative")
+        if self.age < 0:
+            raise ValueError("age must be non-negative")
+        self.sex = self.sex.strip().lower()
+        self.family_branch = self.family_branch.strip().lower()
 
     def workload(self) -> int:
         """Return the number of committees this person currently serves on."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -14,6 +14,17 @@ def test_person_service_cap_validation():
         Person(name="Alice", service_cap=-1)
 
 
+def test_person_age_validation():
+    with pytest.raises(ValueError):
+        Person(name="Alice", age=-1)
+
+
+def test_person_normalization():
+    person = Person(name="Alice", sex=" Female ", family_branch=" North ")
+    assert person.sex == "female"
+    assert person.family_branch == "north"
+
+
 def test_committee_size_validation():
     with pytest.raises(ValueError):
         Committee(name="Test", min_size=2, max_size=1)


### PR DESCRIPTION
## Summary
- expand `Person` model with age, sex, family branch, and interests
- validate age and normalize sex/family branch fields
- test demographic validation and normalization

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf4dd287d48322a246cc36eb5fe3e2